### PR TITLE
Update boot.py - Add auto-boundary

### DIFF
--- a/app/boot.py
+++ b/app/boot.py
@@ -100,48 +100,58 @@ def boot():
 def add_default_presets():
     try:
         Preset.objects.update_or_create(name='Multispectral', system=True,
-                                        defaults={'options': [{'name': 'texturing-skip-global-seam-leveling', 'value': True},
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'texturing-skip-global-seam-leveling', 'value': True},
                                                               {'name': 'radiometric-calibration', 'value': 'camera'},
                                                               ]})
         Preset.objects.update_or_create(name='Volume Analysis', system=True,
-                                        defaults={'options': [{'name': 'dsm', 'value': True},
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'dsm', 'value': True},
                                                               {'name': 'dem-resolution', 'value': '2'},
                                                               {'name': 'pc-geometric', 'value': True},
                                                               {'name': 'pc-quality', 'value': 'high'},
                                                               {'name': 'use-3dmesh', 'value': True},]})
         Preset.objects.update_or_create(name='3D Model', system=True,
-                                        defaults={'options': [{'name': 'mesh-octree-depth', 'value': "12"},
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'mesh-octree-depth', 'value': "12"},
                                                               {'name': 'use-3dmesh', 'value': True},
                                                               {'name': 'pc-geometric', 'value': True},
                                                               {'name': 'pc-quality', 'value': 'high'},
                                                               {'name': 'mesh-size', 'value': '300000'}]})
         Preset.objects.update_or_create(name='Buildings', system=True,
-                                        defaults={'options': [{'name': 'mesh-size', 'value': '300000'},
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'mesh-size', 'value': '300000'},
                                                               {'name': 'pc-geometric', 'value': True},
                                                               {'name': 'pc-quality', 'value': 'high'}]})
         Preset.objects.update_or_create(name='Point of Interest', system=True,
-                                        defaults={'options': [{'name': 'mesh-size', 'value': '300000'},
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'mesh-size', 'value': '300000'},
                                                               {'name': 'pc-geometric', 'value': True},
                                                               {'name': 'use-3dmesh', 'value': True}]})
         Preset.objects.update_or_create(name='Forest', system=True,
-                                        defaults={'options': [{'name': 'min-num-features', 'value': '18000'},
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'min-num-features', 'value': '18000'},
                                                               {'name': 'use-3dmesh', 'value': True},
                                                               {'name': 'pc-geometric', 'value': True},
                                                               {'name': 'feature-quality', 'value': 'ultra'}]})
         Preset.objects.update_or_create(name='DSM + DTM', system=True,
-                                        defaults={
-                                            'options': [{'name': 'dsm', 'value': True}, {'name': 'dtm', 'value': True}]})
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'dsm', 'value': True},
+                                                              {'name': 'dtm', 'value': True}]})
         Preset.objects.update_or_create(name='Fast Orthophoto', system=True,
-                                        defaults={'options': [{'name': 'fast-orthophoto', 'value': True}]})
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'fast-orthophoto', 'value': True}]})
         Preset.objects.update_or_create(name='High Resolution', system=True,
-                                        defaults={'options': [{'name': 'ignore-gsd', 'value': True},
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'ignore-gsd', 'value': True},
                                                               {'name': 'dsm', 'value': True},
                                                               {'name': 'pc-quality', 'value': 'high'},
                                                               {'name': 'dem-resolution', 'value': "2.0"},
                                                               {'name': 'orthophoto-resolution', 'value': "2.0"},
                                                               ]})
         Preset.objects.update_or_create(name='Default', system=True,
-                                        defaults={'options': [{'name': 'dsm', 'value': True}]})
+                                        defaults={'options': [{'name': 'auto-boundary', 'value': True},
+                                                              {'name': 'dsm', 'value': True}]})
 
     except MultipleObjectsReturned:
         # Mostly to handle a legacy code problem where


### PR DESCRIPTION
I think it might be cheap insurance to have it on for all presets, as it certainly can help some datasets that would otherwise fail to reconstruct to reconstruct properly. It has little benefit for at-nadir surveys and processing templates, but sometimes these datasets can have unexpectedtly large reconstruction areas above/below the plane of reconstruction due to things like water or other spectral material in the survey, and this should prevent that edge case from being fatal.